### PR TITLE
use OG source for GH action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Bump Version
         id: bump-version
-        uses: mike-audi/semantic-versioning-maven@1.0.0
+        uses: RichardInnocent/semantic-versioning-maven@v0.0.36
         with:
           access-token: ${{ secrets.github_token }}
           version-prefix:


### PR DESCRIPTION
The original action (https://github.com/RichardInnocent/semantic-versioning-maven) forced all tags to be prefixed with 'v'. @mike-audi forked, and made the prefix configurable. The enhancement was merged back into the original project and released in version 0.0.36. 

This change resets the GH action to be pointed at the original source as to follow updates. 