### PR TITLE
feat(#17): add simple search

### DIFF
--- a/src/main/java/com/mytiki/l0_index/features/FeaturesConfig.java
+++ b/src/main/java/com/mytiki/l0_index/features/FeaturesConfig.java
@@ -9,6 +9,7 @@ import com.mytiki.l0_index.features.latest.address.AddressConfig;
 import com.mytiki.l0_index.features.latest.app.AppConfig;
 import com.mytiki.l0_index.features.latest.block.BlockConfig;
 import com.mytiki.l0_index.features.latest.report.ReportConfig;
+import com.mytiki.l0_index.features.latest.search.SearchConfig;
 import com.mytiki.l0_index.features.latest.txn.TxnConfig;
 import org.springframework.context.annotation.Import;
 
@@ -17,6 +18,7 @@ import org.springframework.context.annotation.Import;
         AddressConfig.class,
         BlockConfig.class,
         TxnConfig.class,
-        ReportConfig.class
+        ReportConfig.class,
+        SearchConfig.class
 })
 public class FeaturesConfig {}

--- a/src/main/java/com/mytiki/l0_index/features/latest/address/AddressRepository.java
+++ b/src/main/java/com/mytiki/l0_index/features/latest/address/AddressRepository.java
@@ -9,9 +9,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AddressRepository extends JpaRepository<AddressDO, Long> {
     Optional<AddressDO> findByAppIdAndAddress(String appId, byte[] address);
     Page<AddressDO> findAllByAppId(String appId, Pageable pageable);
+    List<AddressDO> findByAddress(byte[] address);
 }

--- a/src/main/java/com/mytiki/l0_index/features/latest/address/AddressService.java
+++ b/src/main/java/com/mytiki/l0_index/features/latest/address/AddressService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public class AddressService {
@@ -56,5 +57,10 @@ public class AddressService {
             return repository.save(req);
         }else
             return found.get();
+    }
+
+    public List<AddressDO> findByAddress(String address){
+        byte[] addressBytes = B64.decode(address);
+        return repository.findByAddress(addressBytes);
     }
 }

--- a/src/main/java/com/mytiki/l0_index/features/latest/block/BlockRepository.java
+++ b/src/main/java/com/mytiki/l0_index/features/latest/block/BlockRepository.java
@@ -9,9 +9,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BlockRepository extends JpaRepository<BlockDO, Long> {
     Page<BlockDO> findAllByAddressAppIdAndAddressAddress(String appId, byte[] address, Pageable pageable);
     Optional<BlockDO> findByHashAndAddressAppIdAndAddressAddress(byte[] hash, String appId, byte[] address);
+    List<BlockDO> findByHash(byte[] hash);
 }

--- a/src/main/java/com/mytiki/l0_index/features/latest/search/SearchAO.java
+++ b/src/main/java/com/mytiki/l0_index/features/latest/search/SearchAO.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_index.features.latest.search;
+
+public class SearchAO {
+    private String appId;
+    private String address;
+    private String blockHash;
+    private String txnHash;
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public void setAppId(String appId) {
+        this.appId = appId;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getBlockHash() {
+        return blockHash;
+    }
+
+    public void setBlockHash(String blockHash) {
+        this.blockHash = blockHash;
+    }
+
+    public String getTxnHash() {
+        return txnHash;
+    }
+
+    public void setTxnHash(String txnHash) {
+        this.txnHash = txnHash;
+    }
+}

--- a/src/main/java/com/mytiki/l0_index/features/latest/search/SearchConfig.java
+++ b/src/main/java/com/mytiki/l0_index/features/latest/search/SearchConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_index.features.latest.search;
+
+import com.mytiki.l0_index.features.latest.address.AddressService;
+import com.mytiki.l0_index.features.latest.app.AppService;
+import com.mytiki.l0_index.features.latest.block.BlockService;
+import com.mytiki.l0_index.features.latest.txn.TxnService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+
+public class SearchConfig {
+
+    @Bean
+    public SearchController searchController(@Autowired SearchService service){
+        return new SearchController(service);
+    }
+
+    @Bean
+    public SearchService searchService(
+            @Autowired AppService appService,
+            AddressService addressService,
+            BlockService blockService,
+            TxnService txnService){
+        return new SearchService(appService, addressService, blockService, txnService);
+    }
+}

--- a/src/main/java/com/mytiki/l0_index/features/latest/search/SearchController.java
+++ b/src/main/java/com/mytiki/l0_index/features/latest/search/SearchController.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_index.features.latest.search;
+
+import com.mytiki.l0_index.utilities.Constants;
+import com.mytiki.spring_rest_api.ApiConstants;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "SEARCH")
+@RestController
+@RequestMapping(value = SearchController.PATH_CONTROLLER)
+public class SearchController {
+    public static final String PATH_CONTROLLER = ApiConstants.API_LATEST_ROUTE + "search";
+
+    private final SearchService service;
+
+    public SearchController(SearchService service) {
+        this.service = service;
+    }
+
+    @Operation(operationId = Constants.PROJECT_DASH_PATH +  "-search-get",
+            summary = "Search", description = "Find an app, address, block, or transaction",
+            security = @SecurityRequirement(name = "jwt"))
+    @RequestMapping(method = RequestMethod.GET)
+    public List<SearchAO> get(@RequestParam String id) {
+        return service.search(id);
+    }
+}

--- a/src/main/java/com/mytiki/l0_index/features/latest/search/SearchService.java
+++ b/src/main/java/com/mytiki/l0_index/features/latest/search/SearchService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_index.features.latest.search;
+
+import com.mytiki.l0_index.features.latest.address.AddressDO;
+import com.mytiki.l0_index.features.latest.address.AddressService;
+import com.mytiki.l0_index.features.latest.app.AppAO;
+import com.mytiki.l0_index.features.latest.app.AppService;
+import com.mytiki.l0_index.features.latest.block.BlockDO;
+import com.mytiki.l0_index.features.latest.block.BlockService;
+import com.mytiki.l0_index.features.latest.txn.TxnDO;
+import com.mytiki.l0_index.features.latest.txn.TxnService;
+import com.mytiki.l0_index.utilities.B64;
+import jakarta.transaction.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SearchService {
+
+    private final AppService appService;
+    private final AddressService addressService;
+    private final BlockService blockService;
+    private final TxnService txnService;
+
+    public SearchService(
+            AppService appService,
+            AddressService addressService,
+            BlockService blockService,
+            TxnService txnService) {
+        this.appService = appService;
+        this.addressService = addressService;
+        this.blockService = blockService;
+        this.txnService = txnService;
+    }
+
+    @Transactional
+    public List<SearchAO> search(String id){
+       AppAO app = appService.getApp(id, 0, 1);
+       List<AddressDO> addresses = addressService.findByAddress(id);
+       List<TxnDO> txns = txnService.findByHash(id);
+       List<BlockDO> blocks = blockService.findByHash(id);
+
+       List<SearchAO> res = new ArrayList<>();
+       if(app.getAddresses().getTotalAddresses() > 0){
+           SearchAO appRes = new SearchAO();
+           appRes.setAppId(app.getAppId());
+           res.add(appRes);
+       }
+
+       addresses.forEach(addr -> {
+           SearchAO addrRes = new SearchAO();
+           addrRes.setAddress(B64.encode(addr.getAddress()));
+           addrRes.setAppId(addr.getAppId());
+           res.add(addrRes);
+       });
+
+       blocks.forEach(block -> {
+            SearchAO blockRes = new SearchAO();
+            blockRes.setBlockHash(B64.encode(block.getHash()));
+            blockRes.setAddress(B64.encode(block.getAddress().getAddress()));
+            blockRes.setAppId(block.getAddress().getAppId());
+            res.add(blockRes);
+       });
+
+        txns.forEach(txn -> {
+            SearchAO txnRes = new SearchAO();
+            txnRes.setTxnHash(B64.encode(txn.getHash()));
+            txnRes.setBlockHash(B64.encode(txn.getBlock().getHash()));
+            txnRes.setAddress(B64.encode(txn.getBlock().getAddress().getAddress()));
+            txnRes.setAppId(txn.getBlock().getAddress().getAppId());
+            res.add(txnRes);
+        });
+
+        return res;
+    }
+}

--- a/src/main/java/com/mytiki/l0_index/features/latest/txn/TxnRepository.java
+++ b/src/main/java/com/mytiki/l0_index/features/latest/txn/TxnRepository.java
@@ -8,6 +8,7 @@ package com.mytiki.l0_index.features.latest.txn;
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TxnRepository extends JpaRepository<TxnDO, Long> {
@@ -15,4 +16,5 @@ public interface TxnRepository extends JpaRepository<TxnDO, Long> {
             byte[] txnHash, byte[] blockHash, String appId, byte[] address);
     @Transactional
     void deleteByHash(byte[] hash);
+    List<TxnDO> findByHash(byte[] hash);
 }

--- a/src/main/java/com/mytiki/l0_index/features/latest/txn/TxnService.java
+++ b/src/main/java/com/mytiki/l0_index/features/latest/txn/TxnService.java
@@ -77,6 +77,19 @@ public class TxnService {
         return List.of();
     }
 
+    public TxnDO create(byte[] hash, BlockDO block){
+        TxnDO req = new TxnDO();
+        req.setHash(hash);
+        req.setBlock(block);
+        req.setCreated(ZonedDateTime.now());
+        return repository.save(req);
+    }
+
+    public List<TxnDO> findByHash(String hash){
+        byte[] hashBytes = B64.decode(hash);
+        return repository.findByHash(hashBytes);
+    }
+
     private TxnAOContents resolveContents(TxnContentSchema schema, List<byte[]> bytes){
         switch (schema) {
             case CONSENT -> {
@@ -101,13 +114,5 @@ public class TxnService {
                 return new TxnAOUnknown();
             }
         }
-    }
-
-    public TxnDO create(byte[] hash, BlockDO block){
-        TxnDO req = new TxnDO();
-        req.setHash(hash);
-        req.setBlock(block);
-        req.setCreated(ZonedDateTime.now());
-        return repository.save(req);
     }
 }

--- a/src/test/java/SearchTest.java
+++ b/src/test/java/SearchTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+import com.mytiki.l0_index.features.latest.address.AddressDO;
+import com.mytiki.l0_index.features.latest.address.AddressRepository;
+import com.mytiki.l0_index.features.latest.block.BlockDO;
+import com.mytiki.l0_index.features.latest.block.BlockRepository;
+import com.mytiki.l0_index.features.latest.search.SearchAO;
+import com.mytiki.l0_index.features.latest.search.SearchService;
+import com.mytiki.l0_index.features.latest.txn.TxnDO;
+import com.mytiki.l0_index.features.latest.txn.TxnRepository;
+import com.mytiki.l0_index.main.App;
+import com.mytiki.l0_index.utilities.B64;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = {App.class}
+)
+@ActiveProfiles(profiles = {"ci", "dev", "local"})
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SearchTest {
+
+    @Autowired
+    private TxnRepository txnRepository;
+
+    @Autowired
+    private BlockRepository blockRepository;
+
+    @Autowired
+    private AddressRepository addressRepository;
+
+    @Autowired
+    private SearchService service;
+
+    @Test
+    public void Test_SearchApp_Success() {
+        String appId = UUID.randomUUID().toString();
+        String address = UUID.randomUUID().toString();
+
+        AddressDO testAddress = new AddressDO();
+        testAddress.setAddress(B64.decode(address));
+        testAddress.setAppId(appId);
+        testAddress.setCreated(ZonedDateTime.now());
+        addressRepository.save(testAddress);
+
+        List<SearchAO> found = service.search(appId);
+        assertEquals(1, found.size());
+        assertEquals(appId, found.get(0).getAppId());
+        assertNull(found.get(0).getAddress());
+        assertNull(found.get(0).getBlockHash());
+        assertNull(found.get(0).getTxnHash());
+    }
+
+    @Test
+    public void Test_SearchAddress_Success() {
+        String appId = UUID.randomUUID().toString();
+        String address = UUID.randomUUID().toString();
+
+        AddressDO testAddress = new AddressDO();
+        testAddress.setAddress(B64.decode(address));
+        testAddress.setAppId(appId);
+        testAddress.setCreated(ZonedDateTime.now());
+        addressRepository.save(testAddress);
+
+        List<SearchAO> found = service.search(address);
+        assertEquals(1, found.size());
+        assertEquals(appId, found.get(0).getAppId());
+        assertEquals(address, found.get(0).getAddress());
+        assertNull(found.get(0).getBlockHash());
+        assertNull(found.get(0).getTxnHash());
+    }
+
+    @Test
+    public void Test_SearchBlock_Success() throws MalformedURLException {
+        String appId = UUID.randomUUID().toString();
+        String address = UUID.randomUUID().toString();
+        String hash = UUID.randomUUID().toString();
+        URL src = new URL("http://localhost:8080/mockedBlock");
+
+        AddressDO testAddress = new AddressDO();
+        testAddress.setAddress(B64.decode(address));
+        testAddress.setAppId(appId);
+        testAddress.setCreated(ZonedDateTime.now());
+        addressRepository.save(testAddress);
+
+        BlockDO testBlock = new BlockDO();
+        testBlock.setAddress(testAddress);
+        testBlock.setHash(B64.decode(hash));
+        testBlock.setSrc(src);
+        testBlock.setCreated(ZonedDateTime.now());
+        blockRepository.save(testBlock);
+
+        List<SearchAO> found = service.search(hash);
+        assertEquals(1, found.size());
+        assertEquals(appId, found.get(0).getAppId());
+        assertEquals(address, found.get(0).getAddress());
+        assertEquals(hash, found.get(0).getBlockHash());
+        assertNull(found.get(0).getTxnHash());
+    }
+
+    @Test
+    public void Test_SearchTxn_Success() throws MalformedURLException {
+        String appId = UUID.randomUUID().toString();
+        String address = UUID.randomUUID().toString();
+        String blockHash = UUID.randomUUID().toString();
+        String txnHash = UUID.randomUUID().toString();
+        URL src = new URL("http://localhost:8080/mockedBlock");
+
+        AddressDO testAddress = new AddressDO();
+        testAddress.setAddress(B64.decode(address));
+        testAddress.setAppId(appId);
+        testAddress.setCreated(ZonedDateTime.now());
+        addressRepository.save(testAddress);
+
+        BlockDO testBlock = new BlockDO();
+        testBlock.setAddress(testAddress);
+        testBlock.setHash(B64.decode(blockHash));
+        testBlock.setSrc(src);
+        testBlock.setCreated(ZonedDateTime.now());
+        blockRepository.save(testBlock);
+
+        TxnDO testTxn = new TxnDO();
+        testTxn.setBlock(testBlock);
+        testTxn.setCreated(ZonedDateTime.now());
+        testTxn.setHash(B64.decode(txnHash));
+        txnRepository.save(testTxn);
+
+        List<SearchAO> found = service.search(txnHash);
+        assertEquals(1, found.size());
+        assertEquals(appId, found.get(0).getAppId());
+        assertEquals(address, found.get(0).getAddress());
+        assertEquals(blockHash, found.get(0).getBlockHash());
+        assertEquals(txnHash, found.get(0).getTxnHash());
+    }
+
+    @Test
+    public void Test_SearchNone_Success() {
+        List<SearchAO> found = service.search(UUID.randomUUID().toString());
+        assertEquals(0, found.size());
+    }
+}


### PR DESCRIPTION
Adds a search slice with an API route that:

- Takes a generic string id
- Checks apps, addresses, blocks, and transactions for matches
- Returns a list of all matching results

Includes unit tests.